### PR TITLE
Sync banner, footer and theme behavior with enutie.com

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,49 +1,13 @@
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import SiteBanner from './components/SiteBanner.vue'
+import SiteFooter from './components/SiteFooter.vue'
 import WarmupSession from './components/WarmupSession.vue'
-
-type Theme = 'light' | 'dark'
-
-const THEME_KEY = 'sketcheduler-theme'
-
-const stored = localStorage.getItem(THEME_KEY)
-const theme = ref<Theme>(stored === 'dark' ? 'dark' : 'light')
-
-watchEffect(() => {
-  document.documentElement.setAttribute('data-theme', theme.value)
-  localStorage.setItem(THEME_KEY, theme.value)
-})
-
-const toggleTheme = (): void => {
-  theme.value = theme.value === 'dark' ? 'light' : 'dark'
-}
 </script>
 
 <template>
-  <header class="banner">
-    <div class="banner-brand">
-      <a href="https://enutie.com">ENUTIE</a>
-      <span class="banner-suffix">/ sketcheduler</span>
-    </div>
-    <nav class="banner-nav">
-      <a href="https://blog.enutie.com">Posts</a>
-      <a href="https://enutie.com/games">Games</a>
-      <button class="theme-toggle" type="button" @click="toggleTheme">
-        {{ theme === 'dark' ? 'daylight' : 'lamplit' }}
-      </button>
-    </nav>
-  </header>
-  <div class="brass-band"></div>
-
+  <SiteBanner />
   <main class="shell">
     <WarmupSession />
   </main>
-
-  <footer class="site-footer">
-    <span>© enutie 2026</span>
-    <nav>
-      <a href="https://enutie.com">home</a>
-      <a href="https://blog.enutie.com">blog</a>
-    </nav>
-  </footer>
+  <SiteFooter />
 </template>

--- a/src/components/SiteBanner.vue
+++ b/src/components/SiteBanner.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { activeTheme, toggleTheme } from '../composables/theme'
+
+const HOME = 'https://enutie.com'
+const BLOG = 'https://blog.enutie.com'
+</script>
+
+<template>
+  <header>
+    <div class="banner">
+      <div class="brand">
+        <a :href="HOME" class="wordmark">ENUTIE</a>
+        <span class="suffix">/ sketcheduler</span>
+      </div>
+      <nav class="nav">
+        <a :href="BLOG" class="nav-link">Posts</a>
+        <a :href="`${HOME}/games`" class="nav-link">Games</a>
+        <button
+          type="button"
+          class="theme-switch"
+          :class="{ dark: activeTheme === 'dark' }"
+          role="switch"
+          :aria-checked="activeTheme === 'dark'"
+          aria-label="Toggle dark theme"
+          @click="toggleTheme"
+        >
+          <span class="track"></span>
+          <span class="knob"></span>
+        </button>
+      </nav>
+    </div>
+    <div class="brass-band"></div>
+  </header>
+</template>
+
+<style scoped>
+.banner {
+  background: var(--red);
+  padding: 16px clamp(20px, 5vw, 48px);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.wordmark {
+  font-family: var(--font-head);
+  font-size: 24px;
+  font-weight: 800;
+  color: #f7f3ea;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+}
+
+.suffix {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: #d9a8a0;
+}
+
+.nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  font-family: var(--font-head);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.nav-link {
+  color: #d9a8a0;
+  text-decoration: none;
+  cursor: pointer;
+  padding-bottom: 2px;
+  border-bottom: 3px solid transparent;
+  transition: color 0.15s ease;
+}
+
+.nav-link:hover {
+  color: #f7f3ea;
+}
+
+.nav-link.active {
+  color: #f7f3ea;
+  border-bottom-color: var(--brass);
+}
+
+.theme-switch {
+  position: relative;
+  width: 46px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  flex: none;
+}
+
+.theme-switch .track {
+  position: absolute;
+  inset: 0;
+  border: 1px solid #9c5750;
+  transition: border-color 0.15s ease;
+}
+
+.theme-switch:hover .track {
+  border-color: #d9a8a0;
+}
+
+.theme-switch .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--brass);
+  transition: transform 0.2s ease;
+}
+
+.theme-switch.dark .knob {
+  transform: translateX(24px);
+}
+
+.theme-switch .knob::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2b2118;
+  transform: translate(-50%, -50%);
+}
+
+.theme-switch .knob::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--brass);
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.2s ease;
+}
+
+.theme-switch.dark .knob::after {
+  transform: translate(-15%, -75%) scale(1);
+}
+
+.brass-band {
+  height: 4px;
+  background: var(--brass);
+}
+</style>

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+const year = new Date().getFullYear()
+</script>
+
+<template>
+  <footer class="footer">
+    <div>© enutie {{ year }}</div>
+    <div class="links">
+      <a href="https://enutie.com">home</a>
+      <a href="https://blog.enutie.com">blog</a>
+    </div>
+  </footer>
+</template>
+
+<style scoped>
+.footer {
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  padding: 16px clamp(20px, 5vw, 48px);
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted);
+}
+
+.links {
+  display: flex;
+  gap: 14px;
+}
+
+.links a {
+  color: var(--muted);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.links a:hover {
+  color: var(--red-text);
+}
+</style>

--- a/src/composables/theme.ts
+++ b/src/composables/theme.ts
@@ -1,0 +1,59 @@
+import { ref, watch } from 'vue'
+
+export type Theme = 'light' | 'dark'
+const KEY = 'enutie-theme'
+
+function stored(): Theme | null {
+  try {
+    const v = localStorage.getItem(KEY)
+    return v === 'light' || v === 'dark' ? v : null
+  } catch {
+    return null
+  }
+}
+
+function detectSystem(): Theme {
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  } catch {
+    return 'light'
+  }
+}
+
+export const systemTheme = ref<Theme>(detectSystem())
+try {
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (e) => {
+      systemTheme.value = e.matches ? 'dark' : 'light'
+    })
+} catch {
+}
+
+export const themeOverride = ref<Theme | null>(stored())
+
+export const activeTheme = ref<Theme>('light')
+
+// An explicit toggle choice always wins (persisted, site-wide); with no
+// choice yet, follow the visitor's OS colour-scheme preference.
+watch(
+  [themeOverride, systemTheme],
+  ([override, system]) => {
+    const theme = override ?? system
+    activeTheme.value = theme
+    document.documentElement.dataset.theme = theme === 'dark' ? 'dark' : ''
+  },
+  { immediate: true },
+)
+
+export function setTheme(t: Theme) {
+  themeOverride.value = t
+  try {
+    localStorage.setItem(KEY, t)
+  } catch {
+  }
+}
+
+export function toggleTheme() {
+  setTheme(activeTheme.value === 'dark' ? 'light' : 'dark')
+}

--- a/src/style.css
+++ b/src/style.css
@@ -28,76 +28,16 @@ a {
   color: var(--red-text);
 }
 
-/* ---- banner ---- */
-
-.banner {
-  background: var(--red);
-  padding: 16px clamp(20px, 5vw, 48px);
+#app {
+  min-height: 100vh;
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: var(--s2) var(--s3);
-}
-
-.banner-brand {
-  display: flex;
-  align-items: baseline;
-  gap: var(--s2);
-}
-
-.banner-brand a {
-  font-family: var(--font-head);
-  font-weight: 800;
-  font-size: 24px;
-  color: #f7f3ea;
-  text-decoration: none;
-}
-
-.banner-suffix {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: #d9a8a0;
-}
-
-.banner-nav {
-  display: flex;
-  align-items: baseline;
-  gap: var(--s3);
-}
-
-.banner-nav a,
-.banner-nav button {
-  font-family: var(--font-head);
-  font-weight: 600;
-  font-size: 14px;
-  color: #d9a8a0;
-  text-decoration: none;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.banner-nav a:hover,
-.banner-nav button:hover {
-  color: #f7f3ea;
-}
-
-.theme-toggle {
-  font-family: var(--font-mono) !important;
-  font-size: 11px !important;
-  font-weight: 400 !important;
-}
-
-.brass-band {
-  height: var(--band);
-  background: var(--brass);
+  flex-direction: column;
 }
 
 /* ---- shell ---- */
 
 .shell {
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: 48px 24px 64px;
@@ -209,30 +149,3 @@ a {
   border-top: 4px solid var(--red);
 }
 
-/* ---- footer ---- */
-
-.site-footer {
-  border-top: 1px solid var(--border);
-  padding: var(--s3) clamp(20px, 5vw, 48px);
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: var(--s2) var(--s3);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--muted);
-}
-
-.site-footer a {
-  color: var(--muted);
-  text-decoration: none;
-}
-
-.site-footer a:hover {
-  color: var(--red-text);
-}
-
-.site-footer nav {
-  display: flex;
-  gap: var(--s3);
-}


### PR DESCRIPTION
Follow-up to #13, which was merged just before this commit landed on the branch.

Ports SiteBanner/SiteFooter/the theme composable from the Web repo so both sites share the same implementation: switch-widget theme toggle, center-aligned nav with 24px gaps and reserved underline space, wordmark letter-spacing, and OS colour-scheme default with persisted override.

