### PR TITLE
Match footer links with enutie.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,6 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sketcheduler</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Bitter:wght@400;600;700;800&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sketcheduler",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/bitter": "^5.2.10",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/ibm-plex-sans": "^5.2.8",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -458,6 +461,33 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/bitter": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/bitter/-/bitter-5.2.10.tgz",
+      "integrity": "sha512-oqQgWAp+lgoGX7iFbVSbTkKyz0k8EK8+bLdUKDTqGTjW0HqrCue70v4jwbZvyNV/3DZol/b/L/WpdXfuQXKBUg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+      "integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/bitter": "^5.2.10",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/ibm-plex-sans": "^5.2.8",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -8,6 +8,7 @@ const year = new Date().getFullYear()
     <div class="links">
       <a href="https://blog.enutie.com/index.xml">rss</a>
       <a href="https://github.com/Enutie">github</a>
+      <a href="https://enutie.github.io">bachelor project</a>
       <a href="https://enutie.com">enutie.com</a>
       <a href="https://blog.enutie.com">blog.enutie.com</a>
     </div>

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -6,8 +6,10 @@ const year = new Date().getFullYear()
   <footer class="footer">
     <div>© enutie {{ year }}</div>
     <div class="links">
-      <a href="https://enutie.com">home</a>
-      <a href="https://blog.enutie.com">blog</a>
+      <a href="https://blog.enutie.com/index.xml">rss</a>
+      <a href="https://github.com/Enutie">github</a>
+      <a href="https://enutie.com">enutie.com</a>
+      <a href="https://blog.enutie.com">blog.enutie.com</a>
     </div>
   </footer>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,14 @@
+// Self-hosted fonts (same weights the old Google Fonts link served)
+import '@fontsource/bitter/400.css'
+import '@fontsource/bitter/600.css'
+import '@fontsource/bitter/700.css'
+import '@fontsource/bitter/800.css'
+import '@fontsource/ibm-plex-sans/400.css'
+import '@fontsource/ibm-plex-sans/500.css'
+import '@fontsource/ibm-plex-sans/600.css'
+import '@fontsource/ibm-plex-mono/400.css'
+import '@fontsource/ibm-plex-mono/500.css'
+
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'


### PR DESCRIPTION
Footer link row now mirrors the main site's footer: rss · github · enutie.com · blog.enutie.com.

