### PR TITLE
Pin @enutie/design to https in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
     },
     "node_modules/@enutie/design": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Enutie/design.git#46d628bdb5fd6cfc666cd15ddadcb5abd78b4417",
+      "resolved": "git+https://github.com/Enutie/design.git#46d628bdb5fd6cfc666cd15ddadcb5abd78b4417",
       "dependencies": {
         "@fontsource/bitter": "^5.2.10",
         "@fontsource/ibm-plex-mono": "^5.2.7",


### PR DESCRIPTION
Follow-up to #16, merged just before this landed on the branch. Rewrites the lockfile's resolved URL from git+ssh to git+https so GitHub Actions can fetch the design package — same fix that turned Web's CI green.